### PR TITLE
Fix the problem of incorrectly adding an empty array as an enum type …

### DIFF
--- a/packages/json-schema-editor/type/integer.js
+++ b/packages/json-schema-editor/type/integer.js
@@ -4,7 +4,7 @@ const value = {
     minimum: null,
     exclusiveMaximum:null,
     exclusiveMinimum:null,
-    enum:[]
+    enum:null
 }
 const attr = {
     description: {

--- a/packages/json-schema-editor/type/number.js
+++ b/packages/json-schema-editor/type/number.js
@@ -4,7 +4,7 @@ const value = {
     minimum: null,
     exclusiveMaximum:null,
     exclusiveMinimum:null,
-    enum:[]
+    enum:null
 }
 const attr = {
     description: {


### PR DESCRIPTION
when modifying a field's type to include an enum type, it automatically adds an empty array as the enum type, which may lead to some issues